### PR TITLE
Add two parameters to PostbackAction

### DIFF
--- a/linebot/constants/__init__.py
+++ b/linebot/constants/__init__.py
@@ -12,4 +12,4 @@
 
 """linebot.constants package."""
 
-from .postback_input_option import PostbackInputOption
+from .postback_input_option import PostbackInputOption  # noqa

--- a/linebot/constants/__init__.py
+++ b/linebot/constants/__init__.py
@@ -1,0 +1,15 @@
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+"""linebot.constants package."""
+
+from .postback_input_option import PostbackInputOption

--- a/linebot/constants/postback_input_option.py
+++ b/linebot/constants/postback_input_option.py
@@ -14,6 +14,7 @@
 
 
 class PostbackInputOption:
+    """Constant class for Postback input option"""
     CLOSE_RICH_MENU = "closeRichMenu"
     OPEN_RICH_MENU = "openRichMenu"
     OPEN_KEYBOARD = "openKeyboard"

--- a/linebot/constants/postback_input_option.py
+++ b/linebot/constants/postback_input_option.py
@@ -14,7 +14,8 @@
 
 
 class PostbackInputOption:
-    """Constant class for Postback input option"""
+    """Constant class for Postback input option."""
+
     CLOSE_RICH_MENU = "closeRichMenu"
     OPEN_RICH_MENU = "openRichMenu"
     OPEN_KEYBOARD = "openKeyboard"

--- a/linebot/constants/postback_input_option.py
+++ b/linebot/constants/postback_input_option.py
@@ -1,0 +1,20 @@
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License. You may obtain
+#  a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+
+"""linebot.constants.postback_input_option module."""
+
+
+class PostbackInputOption:
+    CLOSE_RICH_MENU = "closeRichMenu"
+    OPEN_RICH_MENU = "openRichMenu"
+    OPEN_KEYBOARD = "openKeyboard"
+    OPEN_VOICE = "openVoice"

--- a/linebot/models/actions.py
+++ b/linebot/models/actions.py
@@ -73,7 +73,16 @@ class PostbackAction(Action):
     a postback event is returned via webhook with the specified string in the data property.
     """
 
-    def __init__(self, label=None, data=None, display_text=None, text=None, **kwargs):
+    def __init__(
+        self,
+        label=None,
+        data=None,
+        display_text=None,
+        text=None,
+        input_option=None,
+        fill_in_text=None,
+        **kwargs
+    ):
         """__init__ method.
 
         :param str label: Label for the action.
@@ -92,6 +101,8 @@ class PostbackAction(Action):
         self.data = data
         self.display_text = display_text
         self.text = text
+        self.input_option = input_option
+        self.fill_in_text = fill_in_text
 
 
 class MessageAction(Action):

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -15,6 +15,7 @@
 from __future__ import unicode_literals, absolute_import
 
 import unittest
+from linebot.constants.postback_input_option import PostbackInputOption
 
 from linebot.models import (
     PostbackAction,
@@ -34,7 +35,9 @@ class TestActions(SerializeTestCase):
         arg = {
             'label': 'Buy',
             'data': 'action=buy&id=1',
-            'display_text': 'buy'
+            'display_text': 'buy',
+            'input_option': PostbackInputOption.OPEN_KEYBOARD,
+            'fill_in_text': 'fill in text',
         }
         self.assertEqual(
             self.serialize_as_dict(arg, type=self.POSTBACK),


### PR DESCRIPTION
# Overview
On May 13th, a function to open and close the rich menu automatically when you tap the rich menu, etc. were added.

## Related issue
- 

## Reference
https://developers.line.biz/en/news/2022/05/13/richmenu-keyboard/

## Operation check
```python
line_bot_api.reply_message(
    event.reply_token,
    TemplateSendMessage(
        alt_text="Buttons template",
        template=ButtonsTemplate(
            title="タイトル",
            text="テキスト",
            actions=[
                PostbackAction(
                    label="open keyboard",
                    data="data",
                    input_option=PostbackInputOption.OPEN_KEYBOARD,
                    fill_in_text='text'
                ),
            ],
        ),
    ),
)
```

<img src="https://user-images.githubusercontent.com/49806926/168515712-06f6aec8-dd6c-436c-aa52-f4a755c5dc99.jpg" width="400">